### PR TITLE
Fixed TorrcPanel AttributeError in menu actions

### DIFF
--- a/nyx/menu/actions.py
+++ b/nyx/menu/actions.py
@@ -298,7 +298,7 @@ def make_torrc_menu(torrc_panel):
 
   torrc_menu.add(nyx.menu.item.MenuItem('%s Comments' % label, functools.partial(torrc_panel.set_comments_visible, arg)))
 
-  if torrc_panel.show_line_num:
+  if torrc_panel._show_line_numbers:
     label, arg = 'Hide', False
   else:
     label, arg = 'Show', True


### PR DESCRIPTION
TorrcPanel has no attribute `show_line_num`. This previously cause an `AttributeError`. The correct attribute to query is `_show_line_numbers`.
