### PR TITLE
Dropped Stop Tor menu option

### DIFF
--- a/nyx/menu/actions.py
+++ b/nyx/menu/actions.py
@@ -55,8 +55,8 @@ def make_actions_menu():
   Submenu consisting of...
     Close Menu
     New Identity
-    Pause / Unpause
     Reset Tor
+    Pause / Unpause
     Exit
   """
 
@@ -66,10 +66,6 @@ def make_actions_menu():
   actions_menu = nyx.menu.item.Submenu('Actions')
   actions_menu.add(nyx.menu.item.MenuItem('Close Menu', None))
   actions_menu.add(nyx.menu.item.MenuItem('New Identity', header_panel.send_newnym))
-
-  if controller.is_alive():
-    actions_menu.add(nyx.menu.item.MenuItem('Stop Tor', controller.close))
-
   actions_menu.add(nyx.menu.item.MenuItem('Reset Tor', functools.partial(controller.signal, stem.Signal.RELOAD)))
 
   if control.is_paused():


### PR DESCRIPTION
Changes made in this PR:
- Dropped `Stop Tor` menu option
- Fixed order of Submenu elements in comment
