### PR TITLE
Updated --log commandline argument and startup.events

### DIFF
--- a/nyx/arguments.py
+++ b/nyx/arguments.py
@@ -24,7 +24,7 @@ DEFAULT_ARGS = {
   'user_provided_socket': False,
   'config': os.path.join(DATA_DIR, 'nyxrc'),
   'debug_path': None,
-  'logged_events': 'NOTICE,NYX_NOTICE',
+  'logged_events': 'NOTICE,WARN,ERR,NYX_NOTICE,NYX_WARNING,NYX_ERROR',
   'print_version': False,
   'print_help': False,
 }
@@ -137,7 +137,7 @@ def parse(argv):
       try:
         validate_events(arg)
       except ValueError as exc:
-        raise ValueError(msg('usage.unrecognized_log_flags', flags = exc))
+        raise ValueError(msg('usage.unrecognized_log_events', events = exc))
 
       args['logged_events'] = arg
     elif opt in ('-v', '--version'):

--- a/nyx/arguments.py
+++ b/nyx/arguments.py
@@ -164,8 +164,8 @@ def get_help():
     port = DEFAULT_ARGS['control_port'],
     socket = DEFAULT_ARGS['control_socket'],
     config_path = DEFAULT_ARGS['config'],
-    events = DEFAULT_ARGS['logged_events'],
-    event_flags = msg('misc.event_types'),
+    default_events = DEFAULT_ARGS['logged_events'],
+    events = msg('misc.event_types'),
   )
 
 

--- a/nyx/panel/log.py
+++ b/nyx/panel/log.py
@@ -39,7 +39,7 @@ CONFIG = conf.config_dict('nyx', {
   'features.log.prepopulate': True,
   'features.log.prepopulateReadLimit': 5000,
   'features.log.regex': [],
-  'startup.events': 'NOTICE,NYX_NOTICE',
+  'startup.events': 'NOTICE,WARN,ERR,NYX_NOTICE,NYX_WARNING,NYX_ERROR',
 }, conf_handler)
 
 UPDATE_RATE = 0.3

--- a/nyx/panel/log.py
+++ b/nyx/panel/log.py
@@ -39,7 +39,7 @@ CONFIG = conf.config_dict('nyx', {
   'features.log.prepopulate': True,
   'features.log.prepopulateReadLimit': 5000,
   'features.log.regex': [],
-  'startup.events': 'N3',
+  'startup.events': 'NOTICE,NYX_NOTICE',
 }, conf_handler)
 
 UPDATE_RATE = 0.3
@@ -68,7 +68,7 @@ class LogPanel(nyx.panel.DaemonPanel):
   def __init__(self):
     nyx.panel.DaemonPanel.__init__(self, 'log', UPDATE_RATE)
 
-    logged_events = nyx.arguments.expand_events(CONFIG['startup.events'])
+    logged_events = nyx.arguments.validate_events(CONFIG['startup.events'])
     self._event_log = nyx.log.LogGroup(CONFIG['cache.log_panel.size'], group_by_day = True)
     self._event_log_paused = None
     self._event_types = nyx.log.listen_for_events(self._register_tor_event, logged_events)

--- a/nyx/panel/log.py
+++ b/nyx/panel/log.py
@@ -134,21 +134,10 @@ class LogPanel(nyx.panel.DaemonPanel):
   def show_event_selection_prompt(self):
     """
     Prompts the user to select the events being listened for.
-    """
-
-    event_types = nyx.popups.select_event_types()
-
-    if event_types and event_types != self._event_types:
-      self._event_types = nyx.log.listen_for_events(self._register_tor_event, event_types)
-      self.redraw(True)
-
-  def new_show_event_selection_prompt(self):
-    """
-    Prompts the user to select the events being listened for.
     TODO: Replace show_event_selection_prompt() with this method.
     """
 
-    event_types = nyx.popups.new_select_event_types(self._event_types)
+    event_types = nyx.popups.select_event_types(self._event_types)
 
     if event_types and event_types != self._event_types:
       self._event_types = nyx.log.listen_for_events(self._register_tor_event, event_types)
@@ -245,7 +234,6 @@ class LogPanel(nyx.panel.DaemonPanel):
       nyx.panel.KeyHandler('arrows', 'scroll up and down', _scroll, key_func = lambda key: key.is_scroll()),
       nyx.panel.KeyHandler('a', 'save snapshot of the log', self.show_snapshot_prompt),
       nyx.panel.KeyHandler('e', 'change logged events', self.show_event_selection_prompt),
-      nyx.panel.KeyHandler('w', 'new change logged events', self.new_show_event_selection_prompt),
       nyx.panel.KeyHandler('f', 'log regex filter', _pick_filter, 'enabled' if self._filter.selection() else 'disabled'),
       nyx.panel.KeyHandler('u', 'duplicate log entries', _toggle_deduplication, 'visible' if self._show_duplicates else 'hidden'),
       nyx.panel.KeyHandler('c', 'clear event log', _clear_log),

--- a/nyx/popups.py
+++ b/nyx/popups.py
@@ -391,37 +391,7 @@ def select_sort_order(title, options, previous_order, option_colors):
   return new_order
 
 
-def select_event_types():
-  """
-  Presents a chart of event types we support, with a prompt for the user to
-  select a set.
-
-  :returns: **set** of event types the user has selected or **None** if dialog
-    is canceled
-  """
-
-  def _render(subwindow):
-    subwindow.box()
-    subwindow.addstr(0, 0, 'Event Types:', HIGHLIGHT)
-
-    for i, line in enumerate(CONFIG['msg.misc.event_types'].split('\n')):
-      subwindow.addstr(1, i + 1, line[6:])
-
-  with nyx.curses.CURSES_LOCK:
-    nyx.curses.draw(_render, top = _top(), width = 80, height = 16)
-    user_input = nyx.controller.input_prompt('Events to log: ')
-
-    if user_input:
-      try:
-        user_input = user_input.replace(' ', '')  # strip spaces
-        return nyx.arguments.expand_events(user_input)
-      except ValueError as exc:
-        nyx.controller.show_message('Invalid flags: %s' % exc, HIGHLIGHT, max_wait = 2)
-
-    return None
-
-
-def new_select_event_types(initial_selection):
+def select_event_types(initial_selection):
   """
   Presents chart of events for the user to select from.
 

--- a/nyx/settings/strings.cfg
+++ b/nyx/settings/strings.cfg
@@ -63,20 +63,15 @@ msg.debug.header
 |--------------------------------------------------------------------------------
 
 msg.misc.event_types
-|        d DEBUG      a ADDRMAP           r CLIENTS_SEEN      C SIGNAL
-|        i INFO       f AUTHDIR_NEWDESCS  u DESCCHANGED       F STREAM_BW
-|        n NOTICE     j BUILDTIMEOUT_SET  g GUARD             G STATUS_CLIENT
-|        w WARN       b BW                h HS_DESC           H STATUS_GENERAL
-|        e ERR        k CELL_STATS        v HS_DESC_CONTENT   I STATUS_SERVER
-|                     c CIRC              x NETWORK_LIVENESS  s STREAM
-|                     l CIRC_BW           y NEWCONSENSUS      J TB_EMPTY
-|                     m CIRC_MINOR        z NEWDESC           t TRANSPORT_LAUNCHED
-|                     p CONF_CHANGED      B NS
-|                     q CONN_BW           o ORCONN
+|    DEBUG               INFO                NOTICE              WARN              ERR
+|    NYX_DEBUG           NYX_INFO            NYX_NOTICE          NYX_WARNING       NYX_ERROR
 |
-|          DINWE tor runlevel+            A All Events
-|          12345 nyx runlevel+            X No Events
-|                                         U Unknown Events
+|    ADDRMAP             AUTHDIR_NEWDESCS    BUILDTIMEOUT_SET    BW                CELL_STATS
+|    CIRC                CIRC_BW             CIRC_MINOR          CONF_CHANGED      CONN_BW
+|    CLIENTS_SEEN        DESCCHANGED         GUARD               HS_DESC           HS_DESC_CONTENT
+|    NETWORK_LIVENESS    NEWCONSENSUS        NEWDESC             NS                ORCONN
+|    SIGNAL              STREAM_BW           STATUS_CLIENT       STATUS_GENERAL    STATUS_SERVER
+|    STREAM              TB_EMPTY            TRANSPORT_LAUNCHED
 
 msg.setup.unknown_term
 |Unknown $TERM: ({term})
@@ -93,9 +88,9 @@ msg.usage.help_output
 |  -c, --config CONFIG_PATH        loaded configuration options, CONFIG_PATH
 |                                    defaults to: {config_path}
 |  -d, --debug LOG_PATH            writes all nyx logs to the given location
-|  -l, --log EVENT_FLAGS           event types to be logged (default: {events})
+|  -l, --log EVENTS                event types to be logged (default: {default_events})
 |
-|{event_flags}
+|{events}
 |
 |  -v, --version                   provides version information
 |  -h, --help                      presents this help

--- a/nyx/settings/strings.cfg
+++ b/nyx/settings/strings.cfg
@@ -49,7 +49,7 @@ msg.tracker.unable_to_use_resolver Unable to query connections with {old_resolve
 msg.usage.invalid_arguments {error} (for usage provide --help)
 msg.usage.not_a_valid_address '{address_input}' isn't a valid IPv4 address
 msg.usage.not_a_valid_port '{port_input}' isn't a valid port number
-msg.usage.unrecognized_log_flags Unrecognized event flags: {flags}
+msg.usage.unrecognized_log_events Unrecognized events: {events}
 msg.usage.unable_to_set_color_override "{color}" isn't a valid color
 
 msg.debug.header

--- a/test/arguments.py
+++ b/test/arguments.py
@@ -28,8 +28,8 @@ class TestArgumentParsing(unittest.TestCase):
     args = parse(['--debug', '/tmp/dump'])
     self.assertEqual('/tmp/dump', args.debug_path)
 
-    args = parse(['--log', 'D1'])
-    self.assertEqual('D1', args.logged_events)
+    args = parse(['--log', 'DEBUG,NYX_DEBUG'])
+    self.assertEqual('DEBUG,NYX_DEBUG', args.logged_events)
 
     args = parse(['--version'])
     self.assertEqual(True, args.print_version)
@@ -41,8 +41,8 @@ class TestArgumentParsing(unittest.TestCase):
     args = parse(['-i', '1643'])
     self.assertEqual(1643, args.control_port)
 
-    args = parse(['-l', 'we', '-c', '/tmp/cfg'])
-    self.assertEqual('we', args.logged_events)
+    args = parse(['-l', 'WARN,ERR', '-c', '/tmp/cfg'])
+    self.assertEqual('WARN,ERR', args.logged_events)
     self.assertEqual('/tmp/cfg', args.config)
 
   def test_that_we_reject_unrecognized_arguments(self):

--- a/test/popups.py
+++ b/test/popups.py
@@ -94,25 +94,6 @@ Config Option Ordering:--------------------------------------------------------+
 
 EXPECTED_EVENT_SELECTOR = """
 Event Types:-------------------------------------------------------------------+
-|  d DEBUG      a ADDRMAP           r CLIENTS_SEEN      C SIGNAL               |
-|  i INFO       f AUTHDIR_NEWDESCS  u DESCCHANGED       F STREAM_BW            |
-|  n NOTICE     j BUILDTIMEOUT_SET  g GUARD             G STATUS_CLIENT        |
-|  w WARN       b BW                h HS_DESC           H STATUS_GENERAL       |
-|  e ERR        k CELL_STATS        v HS_DESC_CONTENT   I STATUS_SERVER        |
-|               c CIRC              x NETWORK_LIVENESS  s STREAM               |
-|               l CIRC_BW           y NEWCONSENSUS      J TB_EMPTY             |
-|               m CIRC_MINOR        z NEWDESC           t TRANSPORT_LAUNCHED   |
-|               p CONF_CHANGED      B NS                                       |
-|               q CONN_BW           o ORCONN                                   |
-|                                                                              |
-|    DINWE tor runlevel+            A All Events                               |
-|    12345 nyx runlevel+            X No Events                                |
-|                                   U Unknown Events                           |
-+------------------------------------------------------------------------------+
-""".strip()
-
-EXPECTED_NEW_EVENT_SELECTOR = """
-Event Types:-------------------------------------------------------------------+
 |Tor Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
 |Nyx Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
 +------------------------------------------------------------------------------+
@@ -121,7 +102,7 @@ Event Types:-------------------------------------------------------------------+
 +------------------------------------------------------------------------------+
 """.strip()
 
-EXPECTED_NEW_EVENT_SELECTOR_UP_DOWN = """
+EXPECTED_EVENT_SELECTOR_UP_DOWN = """
 Event Types:-------------------------------------------------------------------+
 |Tor Runlevel:    [X] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
 |Nyx Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
@@ -132,7 +113,7 @@ Event Types:-------------------------------------------------------------------+
 +------------------------------------------------------------------------------+
 """.strip()
 
-EXPECTED_NEW_EVENT_SELECTOR_LEFT_RIGHT = """
+EXPECTED_EVENT_SELECTOR_LEFT_RIGHT = """
 Event Types:-------------------------------------------------------------------+
 |Tor Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
 |Nyx Runlevel:    [X] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
@@ -143,7 +124,7 @@ Event Types:-------------------------------------------------------------------+
 +------------------------------------------------------------------------------+
 """.strip()
 
-EXPECTED_NEW_EVENT_SELECTOR_CANCEL = """
+EXPECTED_EVENT_SELECTOR_CANCEL = """
 Event Types:-------------------------------------------------------------------+
 |Tor Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
 |Nyx Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
@@ -154,7 +135,7 @@ Event Types:-------------------------------------------------------------------+
 +------------------------------------------------------------------------------+
 """.strip()
 
-EXPECTED_NEW_EVENT_SELECTOR_INITIAL_SELECTION = """
+EXPECTED_EVENT_SELECTOR_INITIAL_SELECTION = """
 Event Types:-------------------------------------------------------------------+
 |Tor Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
 |Nyx Runlevel:    [ ] DEBUG    [ ] INFO    [ ] NOTICE    [ ] WARN    [ ] ERR   |
@@ -348,98 +329,82 @@ class TestPopups(unittest.TestCase):
 
   @require_curses
   @patch('nyx.popups._top', Mock(return_value = 0))
-  @patch('nyx.controller.input_prompt', Mock(return_value = None))
-  def test_select_event_types_when_canceled(self):
-    rendered = test.render(nyx.popups.select_event_types)
-    self.assertEqual(EXPECTED_EVENT_SELECTOR, rendered.content)
-    self.assertEqual(None, rendered.return_value)
-
-  @require_curses
-  @patch('nyx.popups._top', Mock(return_value = 0))
-  @patch('nyx.controller.input_prompt', Mock(return_value = '2bwe'))
-  def test_select_event_types_with_input(self):
-    rendered = test.render(nyx.popups.select_event_types)
-    self.assertEqual(EXPECTED_EVENT_SELECTOR, rendered.content)
-    self.assertEqual(set(['NYX_INFO', 'ERR', 'WARN', 'BW', 'NYX_ERROR', 'NYX_WARNING', 'NYX_NOTICE']), rendered.return_value)
-
-  @require_curses
-  @patch('nyx.popups._top', Mock(return_value = 0))
   @patch('nyx.tor_controller')
-  def test_new_select_event_types(self, controller_mock):
+  def test_select_event_types(self, controller_mock):
     controller = Mock()
     controller.get_info.return_value = 'DEBUG INFO NOTICE WARN ERR CIRC CIRC_MINOR'
     controller_mock.return_value = controller
 
     def draw_func():
       with mock_keybindings(curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_ENTER):
-        return nyx.popups.new_select_event_types([])
+        return nyx.popups.select_event_types([])
 
     rendered = test.render(draw_func)
-    self.assertEqual(EXPECTED_NEW_EVENT_SELECTOR, rendered.content)
+    self.assertEqual(EXPECTED_EVENT_SELECTOR, rendered.content)
     self.assertEqual(set([]), rendered.return_value)
 
   @require_curses
   @patch('nyx.popups._top', Mock(return_value = 0))
   @patch('nyx.tor_controller')
-  def test_new_select_event_types_up_down(self, controller_mock):
+  def test_select_event_types_up_down(self, controller_mock):
     controller = Mock()
     controller.get_info.return_value = 'DEBUG INFO NOTICE WARN ERR CIRC CIRC_MINOR STREAM ORCONN BW'
     controller_mock.return_value = controller
 
     def draw_func():
       with mock_keybindings(curses.KEY_UP, curses.KEY_ENTER, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_ENTER):
-        return nyx.popups.new_select_event_types([])
+        return nyx.popups.select_event_types([])
 
     rendered = test.render(draw_func)
-    self.assertEqual(EXPECTED_NEW_EVENT_SELECTOR_UP_DOWN, rendered.content)
+    self.assertEqual(EXPECTED_EVENT_SELECTOR_UP_DOWN, rendered.content)
     self.assertEqual(set(['DEBUG']), rendered.return_value)
 
   @require_curses
   @patch('nyx.popups._top', Mock(return_value = 0))
   @patch('nyx.tor_controller')
-  def test_new_select_event_types_left_right(self, controller_mock):
+  def test_select_event_types_left_right(self, controller_mock):
     controller = Mock()
     controller.get_info.return_value = 'DEBUG INFO NOTICE WARN ERR CIRC CIRC_MINOR STREAM ORCONN BW'
     controller_mock.return_value = controller
 
     def draw_func():
       with mock_keybindings(curses.KEY_LEFT, curses.KEY_DOWN, curses.KEY_ENTER, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_RIGHT, curses.KEY_RIGHT, curses.KEY_LEFT, curses.KEY_ENTER):
-        return nyx.popups.new_select_event_types([])
+        return nyx.popups.select_event_types([])
 
     rendered = test.render(draw_func)
-    self.assertEqual(EXPECTED_NEW_EVENT_SELECTOR_LEFT_RIGHT, rendered.content)
+    self.assertEqual(EXPECTED_EVENT_SELECTOR_LEFT_RIGHT, rendered.content)
     self.assertEqual(set(['NYX_DEBUG']), rendered.return_value)
 
   @require_curses
   @patch('nyx.popups._top', Mock(return_value = 0))
   @patch('nyx.tor_controller')
-  def test_new_select_event_types_cancel(self, controller_mock):
+  def test_select_event_types_cancel(self, controller_mock):
     controller = Mock()
     controller.get_info.return_value = 'DEBUG INFO NOTICE WARN ERR CIRC CIRC_MINOR STREAM ORCONN BW'
     controller_mock.return_value = controller
 
     def draw_func():
       with mock_keybindings(curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_RIGHT, curses.KEY_ENTER):
-        return nyx.popups.new_select_event_types([])
+        return nyx.popups.select_event_types([])
 
     rendered = test.render(draw_func)
-    self.assertEqual(EXPECTED_NEW_EVENT_SELECTOR_CANCEL, rendered.content)
+    self.assertEqual(EXPECTED_EVENT_SELECTOR_CANCEL, rendered.content)
     self.assertEqual(None, rendered.return_value)
 
   @require_curses
   @patch('nyx.popups._top', Mock(return_value = 0))
   @patch('nyx.tor_controller')
-  def test_new_select_event_types_initial_selection(self, controller_mock):
+  def test_select_event_types_initial_selection(self, controller_mock):
     controller = Mock()
     controller.get_info.return_value = 'DEBUG INFO NOTICE WARN ERR CIRC CIRC_MINOR STREAM ORCONN BW'
     controller_mock.return_value = controller
 
     def draw_func():
       with mock_keybindings(curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_DOWN, curses.KEY_ENTER):
-        return nyx.popups.new_select_event_types(['CIRC_MINOR'])
+        return nyx.popups.select_event_types(['CIRC_MINOR'])
 
     rendered = test.render(draw_func)
-    self.assertEqual(EXPECTED_NEW_EVENT_SELECTOR_INITIAL_SELECTION, rendered.content)
+    self.assertEqual(EXPECTED_EVENT_SELECTOR_INITIAL_SELECTION, rendered.content)
     self.assertEqual(set(['CIRC_MINOR']), rendered.return_value)
 
   @require_curses


### PR DESCRIPTION
Updated --log commandline argument and startup.events to have the event names such as `DEBUG,INFO,NOTICE` rather than having arcane letters.
